### PR TITLE
LOG.err changed to LOG.error

### DIFF
--- a/zvmsdk/smutclient.py
+++ b/zvmsdk/smutclient.py
@@ -2018,7 +2018,7 @@ class SMUTClient(object):
             }[scheme]
         except KeyError:
             msg = ("No backend found for '%s'" % scheme)
-            LOG.err(msg)
+            LOG.error(msg)
             raise exception.SDKImageOperationError(rs=2, schema=scheme)
 
     def _get_md5sum(self, fpath):


### PR DESCRIPTION
Fixed images POST:

    "errmsg": "Unexpected internal error in ZVM SDK, error: (127.0.0.1:57244) SDK server got unexpected exception: AttributeError(\"'Logger' object has no attribute 'err'\",)",